### PR TITLE
Start server only after DB connected

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,7 @@ const port = process.env.PORT || 8081;
 const basicroute = require('./routes/basicroute');
 const passport = require('passport');
 const apiRoutes = require('./routes/api/index');
-require('./services/mongodbConnect');
+require('./services/mongodbConnect')(app);
 
 // Bodyparser middleware
 app.use(express.urlencoded({extended: false}));
@@ -23,8 +23,10 @@ app.get('/', (req, res) => {
 app.use('/api', apiRoutes);
 app.use('/basicroute', basicroute);
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}!`);
+app.once('ready', () => {
+  app.listen(port, () => {
+    console.log(`Database connected. App listening on port ${port}!`)
+  });
 });
 
 module.exports = app;

--- a/server/index.js
+++ b/server/index.js
@@ -25,7 +25,7 @@ app.use('/basicroute', basicroute);
 
 app.once('ready', () => {
   app.listen(port, () => {
-    console.log(`Database connected. App listening on port ${port}!`)
+    console.log(`Database connected. App listening on port ${port}!`);
   });
 });
 

--- a/server/services/mongodbConnect.js
+++ b/server/services/mongodbConnect.js
@@ -1,25 +1,30 @@
 const mongoose = require('mongoose');
 const keys = require('../config/keys');
-
-// connection to mongodb
 const options = {
   useUnifiedTopology: true,
   useNewUrlParser: true,
   dbName: 'QuikBorrow',
 };
 
-mongoose.connect(keys.mongoURI, options)
-    .then(() => console.log('Successfully connected to database'))
-    .catch((err) => console.log('Database Connection error', err));
+/**
+ * @typedef {import('express').Express} ExpressApplication
+ */
 
-// get connection
-const db = mongoose.connection;
-db.on('error', (err) => {
-  console.log('Failed to obtain database connection', err);
-});
+/**
+ * @param {ExpressApplication} expressApp
+ */
+module.exports = (expressApp) => {
+  mongoose.connect(keys.mongoURI, options)
+      .catch((err) => {
+        console.log(err);
+        process.exit(1);
+      });
 
-db.once('open', () => {
-  console.log('Successfully retrieved database connection');
-});
+  // get connection
+  const db = mongoose.connection;
+  db.on('error', (err) => {
+    console.log('Database connection error', err);
+  });
 
-module.exports = db;
+  db.once('open', () => expressApp.emit('ready'));
+};


### PR DESCRIPTION
it is _really_ annoying when mongoose doesn't throw any errors for database queries when the database connection has not been established