### PR TITLE
Add lint-fix and use nodemon for npm run dev

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "lint-fix": "eslint src --fix"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -15,13 +15,14 @@
     "install-client": "cd client && npm ci",
     "postinstall": "npm run install-server && npm run install-client",
     "start": "cd server && npm start",
-    "dev": "concurrently  \"npm start\" \"cd client && npm start\"",
+    "dev": "concurrently  \"cd server && npm run dev\" \"cd client && npm start\"",
     "test-client": "cd client && npm test",
     "test-server": "cd server && npm test",
     "test": "npm run test-server && npm run test-client",
     "lint-client": "cd client && npm run lint",
     "lint-server": "cd server && npm run lint",
-    "lint": "npm run lint-client && npm run lint-server"
+    "lint": "npm run lint-client && npm run lint-server",
+    "lint-fix": "concurrently \"cd client && npm run lint-fix\" \"cd server && npm run lint-fix\""
   },
   "engines": {
     "node": "10.x",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "test-unit": "jest unit\\.test\\.js$ --detectOpenHandles --forceExit",
     "test-int": "jest int\\.test\\.js$ --detectOpenHandles --forceExit",
     "start": "node index.js",
-    "server": "nodemon index.js",
+    "dev": "nodemon index.js",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix"
   },


### PR DESCRIPTION
Added lint-fix to client package, root package, and server package because we all keep getting lint tests failing after we commit lol, so preferably we run this script to auto-fix what it can before pushing

Made `npm run dev` to run with nodemon in /server