### PR TITLE
Add unit tests for items controller and services

### DIFF
--- a/server/controllers/items.unit.test.js
+++ b/server/controllers/items.unit.test.js
@@ -1,0 +1,47 @@
+const itemsController = require('./items');
+const itemServices = require('../services/items');
+
+jest.mock('../services/items');
+
+describe('controller/items', function() {
+  describe('create', function() {
+    it('returns the created item', async function() {
+      const request = {body: {}};
+      const response = {json: jest.fn()};
+      const item = {foo: 'bar'};
+      itemServices.createItem.mockResolvedValueOnce(item);
+      await itemsController.create(request, response);
+      expect(response.json).toHaveBeenCalledWith(item);
+    });
+  });
+  describe('get', function() {
+    it('returns the item', async function() {
+      const request = {params: {itemId: '2qw3eit8ghj'}};
+      const response = {json: jest.fn()};
+      const item = {a: 'b'};
+      itemServices.findItem.mockResolvedValueOnce(item);
+      await itemsController.get(request, response);
+      expect(response.json).toHaveBeenCalledWith(item);
+    });
+  });
+  describe('getAll', function() {
+    it('returns the items', async function() {
+      const request = {params: {itemId: '2qw3eit8ghj1'}};
+      const response = {json: jest.fn()};
+      const items = [{a: 'ba'}];
+      itemServices.findAllItems.mockResolvedValueOnce(items);
+      await itemsController.getAll(request, response);
+      expect(response.json).toHaveBeenCalledWith(items);
+    });
+  });
+  describe('rent', function() {
+    it('returns the items', async function() {
+      const request = {params: {itemId: '2qw3eit8ghj1'}};
+      const response = {json: jest.fn()};
+      const item = {ab: 'ba'};
+      itemServices.rentItem.mockResolvedValueOnce(item);
+      await itemsController.rent(request, response);
+      expect(response.json).toHaveBeenCalledWith(item);
+    });
+  });
+});

--- a/server/middleware/shared/validatorErrors.unit.test.js
+++ b/server/middleware/shared/validatorErrors.unit.test.js
@@ -1,0 +1,33 @@
+const validatorErrors = require('./validatorErrors');
+const {validationResult} = require('express-validator');
+
+jest.mock('express-validator');
+
+/**
+ * Mock Response function
+ */
+function Response() {
+  this.status = jest.fn(() => this);
+  this.json = jest.fn();
+}
+
+describe('middleware/shared/validatorErrors', function() {
+  it('calls next if errors is empty', function() {
+    const request = {};
+    const response = new Response();
+    const next = jest.fn();
+    validationResult.mockReturnValueOnce({isEmpty: () => true});
+    validatorErrors(request, response, next);
+    expect(next).toHaveBeenCalled();
+  });
+  it('sends a 422 status and errors if errors is not empty', function() {
+    const request = {};
+    const response = new Response();
+    const errorsArray = [{a: 1}, {b: 2}];
+    const validation = {isEmpty: () => false, array: () => errorsArray};
+    validationResult.mockReturnValueOnce(validation);
+    validatorErrors(request, response);
+    expect(response.status).toHaveBeenCalledWith(422);
+    expect(response.json).toHaveBeenCalledWith({errors: errorsArray});
+  });
+});

--- a/server/services/items.unit.test.js
+++ b/server/services/items.unit.test.js
@@ -1,0 +1,70 @@
+const itemServices = require('./items');
+const Item = require('../models/Item');
+
+jest.mock('../models/Item');
+
+describe('services/item', function() {
+  afterEach(function() {
+    Item.mockReset();
+  });
+  describe('createItem', function() {
+    it('creates a new item with the data and saves it', async function() {
+      const data = {a: 1, b: 2};
+      await itemServices.createItem(data);
+      expect(Item).toHaveBeenCalledWith(data);
+      expect(Item.mock.instances[0].save).toHaveBeenCalled();
+    });
+    it('returns the created item', async function() {
+      const data = {a: 1, b: 2};
+      const returned = await itemServices.createItem(data);
+      expect(Item).toHaveBeenCalledWith(data);
+      expect(Item.mock.instances[0]).toEqual(returned);
+    });
+  });
+  describe('findItem', function() {
+    it('finds an item by id', async function() {
+      const id = '12e';
+      await itemServices.findItem(id);
+      expect(Item.findById).toHaveBeenCalledWith(id);
+    });
+    it('returns the item found by id', async function() {
+      const id = 'we234t';
+      const item = {hugs: 'kisses'};
+      Item.findById.mockResolvedValueOnce(item);
+      const returned = await itemServices.findItem(id);
+      expect(returned).toEqual(item);
+    });
+  });
+  describe('findAllItems', function() {
+    it('finds all items', async function() {
+      await itemServices.findAllItems();
+      expect(Item.find).toHaveBeenCalledWith({});
+    });
+    it('returns the items found', async function() {
+      const items = [{hugs: 'kisses'}, {HAH: 'GOTEEEM'}];
+      Item.find.mockResolvedValueOnce(items);
+      const returned = await itemServices.findAllItems();
+      expect(returned).toEqual(items);
+    });
+  });
+  describe('rentItem', function() {
+    it('finds the item by id', async function() {
+      const id = '12e';
+      Item.findById.mockResolvedValueOnce({save: jest.fn()});
+      await itemServices.rentItem(id);
+      expect(Item.findById).toHaveBeenCalledWith(id);
+    });
+    it('sets the availability to false', async function() {
+      const item = {a: 1, boo: 2, save: jest.fn()};
+      Item.findById.mockResolvedValueOnce(item);
+      await itemServices.rentItem();
+      expect(item.availability).toEqual(false);
+    });
+    it('calls save', async function() {
+      const item = {a: 1, boo: 2, save: jest.fn()};
+      Item.findById.mockResolvedValueOnce(item);
+      await itemServices.rentItem();
+      expect(item.save).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
As a side note, something I just realized the `GET /api/items/:itemId/rent` route could be replaced by a generic `PATCH /api/items/:itemId` to just edit any keys of an Item, which includes availability - otherwise we'll have any make more routes to edit other keys of an Item